### PR TITLE
Add QML/ QtQuick Depends

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -195,17 +195,17 @@ $($(1)_configured): | $($(1)_dependencies) $($(1)_preprocessed)
 	$(AT)echo Configuring $(1)...
 	$(AT)rm -rf $(host_prefix); mkdir -p $(host_prefix)/lib; cd $(host_prefix); $(foreach package,$($(1)_all_dependencies), tar --no-same-owner -xf $($(package)_cached); )
 	$(AT)mkdir -p $$(@D)
-	$(AT)+cd $$(@D); $($(1)_config_env) $(call $(1)_config_cmds, $(1))
+	$(AT)+cd $$(@D); export $($(1)_config_env); $(call $(1)_config_cmds, $(1))
 	$(AT)touch $$@
 $($(1)_built): | $($(1)_configured)
 	$(AT)echo Building $(1)...
 	$(AT)mkdir -p $$(@D)
-	$(AT)+cd $$(@D); $($(1)_build_env) $(call $(1)_build_cmds, $(1))
+	$(AT)+cd $$(@D); export $($(1)_build_env); $(call $(1)_build_cmds, $(1))
 	$(AT)touch $$@
 $($(1)_staged): | $($(1)_built)
 	$(AT)echo Staging $(1)...
 	$(AT)mkdir -p $($(1)_staging_dir)/$(host_prefix)
-	$(AT)cd $($(1)_build_dir); $($(1)_stage_env) $(call $(1)_stage_cmds, $(1))
+	$(AT)cd $($(1)_build_dir); export $($(1)_stage_env); $(call $(1)_stage_cmds, $(1))
 	$(AT)rm -rf $($(1)_extract_dir)
 	$(AT)touch $$@
 $($(1)_postprocessed): | $($(1)_staged)

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -21,8 +21,16 @@ $(package)_qttranslations_sha256_hash=fb5a47799754af73d3bf501fe513342cfe2fc37f64
 $(package)_qttools_file_name=qttools-$($(package)_suffix)
 $(package)_qttools_sha256_hash=a97556eb7b2f30252cdd8a598c396cfce2b2f79d2bae883af6d3b26a2cdcc63c
 
+$(package)_qtdeclarative_file_name=qtdeclarative-$($(package)_suffix)
+$(package)_qtdeclarative_sha256_hash=b4e47b6038f3c604dee8128aeed12a0e9558a7b2bba63a2c44e4ad0743de5450
+
+$(package)_qtquickcontrols2_file_name= qtquickcontrols2-$($(package)_suffix)
+$(package)_qtquickcontrols2_sha256_hash=6c1e47188facca82f443e2d3d9692d5a9574db073c37e218b1d89f795b697018
+
 $(package)_extra_sources  = $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)
+$(package)_extra_sources += $($(package)_qtdeclarative_file_name)
+$(package)_extra_sources += $($(package)_qtquickcontrols2_file_name)
 
 define $(package)_set_vars
 $(package)_config_opts_release = -release
@@ -179,7 +187,9 @@ endef
 define $(package)_fetch_cmds
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttranslations_file_name),$($(package)_qttranslations_file_name),$($(package)_qttranslations_sha256_hash)) && \
-$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttools_file_name),$($(package)_qttools_file_name),$($(package)_qttools_sha256_hash))
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttools_file_name),$($(package)_qttools_file_name),$($(package)_qttools_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtdeclarative_file_name),$($(package)_qtdeclarative_file_name),$($(package)_qtdeclarative_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtquickcontrols2_file_name),$($(package)_qtquickcontrols2_file_name),$($(package)_qtquickcontrols2_sha256_hash))
 endef
 
 define $(package)_extract_cmds
@@ -193,7 +203,11 @@ define $(package)_extract_cmds
   mkdir qttranslations && \
   tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qttranslations_file_name) -C qttranslations && \
   mkdir qttools && \
-  tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qttools_file_name) -C qttools
+  tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qttools_file_name) -C qttools && \
+  mkdir qtdeclarative && \
+  tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtdeclarative_file_name) -C qtdeclarative && \
+  mkdir qtquickcontrols2 && \
+  tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtquickcontrols2_file_name) -C qtquickcontrols2
 endef
 
 # Preprocessing steps work as follows:
@@ -262,7 +276,9 @@ define $(package)_config_cmds
   cd ../qttranslations && ../qtbase/bin/qmake qttranslations.pro -o Makefile && \
   cd translations && ../../qtbase/bin/qmake translations.pro -o Makefile && cd ../.. && \
   cd qttools/src/linguist/lrelease/ && ../../../../qtbase/bin/qmake lrelease.pro -o Makefile && \
-  cd ../lupdate/ && ../../../../qtbase/bin/qmake lupdate.pro -o Makefile && cd ../../../..
+  cd ../lupdate/ && ../../../../qtbase/bin/qmake lupdate.pro -o Makefile && cd ../../../.. && \
+  cd qtdeclarative && ../qtbase/bin/qmake qtdeclarative.pro -o Makefile && cd .. && \
+  cd qtquickcontrols2 && ../qtbase/bin/qmake qtquickcontrols2.pro -o Makefile && cd ..
 endef
 
 define $(package)_build_cmds
@@ -270,6 +286,9 @@ define $(package)_build_cmds
   $(MAKE) -C ../qttools/src/linguist/lrelease && \
   $(MAKE) -C ../qttools/src/linguist/lupdate && \
   $(MAKE) -C ../qttranslations
+  $(MAKE) -C ../qttranslations && \
+  $(MAKE) -C ../qtdeclarative && \
+  $(MAKE) -C ../qtquickcontrols2
 endef
 
 define $(package)_stage_cmds
@@ -277,6 +296,8 @@ define $(package)_stage_cmds
   $(MAKE) -C qttools/src/linguist/lrelease INSTALL_ROOT=$($(package)_staging_dir) install_target && \
   $(MAKE) -C qttools/src/linguist/lupdate INSTALL_ROOT=$($(package)_staging_dir) install_target && \
   $(MAKE) -C qttranslations INSTALL_ROOT=$($(package)_staging_dir) install_subtargets && \
+  $(MAKE) -C qtdeclarative INSTALL_ROOT=$($(package)_staging_dir) install_subtargets && \
+  $(MAKE) -C qtquickcontrols2 INSTALL_ROOT=$($(package)_staging_dir) install_subtargets && \
   if `test -f qtbase/src/plugins/platforms/xcb/xcb-static/libxcb-static.a`; then \
     cp qtbase/src/plugins/platforms/xcb/xcb-static/libxcb-static.a $($(package)_staging_prefix_dir)/lib; \
   fi

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -295,8 +295,7 @@ define $(package)_config_cmds
   cd .. && \
   ./configure $($(package)_config_opts) && \
   echo "host_build: QT_CONFIG ~= s/system-zlib/zlib" >> qtbase/mkspecs/qconfig.pri && \
-  echo "CONFIG += force_bootstrap" >> qtbase/mkspecs/qconfig.pri  && \
-  echo "****************CONFIGURING****************"
+  echo "CONFIG += force_bootstrap" >> qtbase/mkspecs/qconfig.pri
 endef
 
 define $(package)_build_cmds

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -13,6 +13,7 @@ $(package)_patches+= fix_rcc_determinism.patch fix_riscv64_arch.patch xkb-defaul
 $(package)_patches+= fix_android_qmake_conf.patch fix_android_jni_static.patch dont_hardcode_pwd.patch
 $(package)_patches+= freetype_back_compat.patch drop_lrelease_dependency.patch fix_powerpc_libpng.patch
 $(package)_patches+= fix_mingw_cross_compile.patch fix_qpainter_non_determinism.patch
+$(package)_patches+= .configure qt.pro .gitmodules
 
 # Update OSX_QT_TRANSLATIONS when this is updated
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
@@ -24,11 +25,20 @@ $(package)_qttools_sha256_hash=a97556eb7b2f30252cdd8a598c396cfce2b2f79d2bae883af
 $(package)_qtdeclarative_file_name=qtdeclarative-$($(package)_suffix)
 $(package)_qtdeclarative_sha256_hash=b4e47b6038f3c604dee8128aeed12a0e9558a7b2bba63a2c44e4ad0743de5450
 
-$(package)_qtquickcontrols2_file_name= qtquickcontrols2-$($(package)_suffix)
+$(package)_qtquickcontrols2_file_name=qtquickcontrols2-$($(package)_suffix)
 $(package)_qtquickcontrols2_sha256_hash=6c1e47188facca82f443e2d3d9692d5a9574db073c37e218b1d89f795b697018
+
+$(package)_qtcharts_file_name=qtcharts-$($(package)_suffix)
+$(package)_qtcharts_sha256_hash=a75f89c0081af9635b50cab335a4871d476b36abc8a11dc4f24724bd3cf42437
+
+$(package)_qtgraphicaleffects_file_name=qtgraphicaleffects-$($(package)_suffix)
+$(package)_qtgraphicaleffects_sha256_hash=7f0d47ed7a92440de8d4a149210ecb76f2020586d7704388f5fd69063ab01a1b
 
 $(package)_extra_sources  = $($(package)_qttranslations_file_name)
 $(package)_extra_sources += $($(package)_qttools_file_name)
+$(package)_extra_sources += $($(package)_qtcharts_file_name)
+$(package)_extra_sources += $($(package)_qtandroidextras_file_name)
+$(package)_extra_sources += $($(package)_qtgraphicaleffects_file_name)
 $(package)_extra_sources += $($(package)_qtdeclarative_file_name)
 $(package)_extra_sources += $($(package)_qtquickcontrols2_file_name)
 
@@ -188,6 +198,8 @@ define $(package)_fetch_cmds
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttranslations_file_name),$($(package)_qttranslations_file_name),$($(package)_qttranslations_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_qttools_file_name),$($(package)_qttools_file_name),$($(package)_qttools_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtcharts_file_name),$($(package)_qtcharts_file_name),$($(package)_qtcharts_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtgraphicaleffects_file_name),$($(package)_qtgraphicaleffects_file_name),$($(package)_qtgraphicaleffects_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtdeclarative_file_name),$($(package)_qtdeclarative_file_name),$($(package)_qtdeclarative_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_qtquickcontrols2_file_name),$($(package)_qtquickcontrols2_file_name),$($(package)_qtquickcontrols2_sha256_hash))
 endef
@@ -197,6 +209,10 @@ define $(package)_extract_cmds
   echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_qttranslations_sha256_hash)  $($(package)_source_dir)/$($(package)_qttranslations_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_qttools_sha256_hash)  $($(package)_source_dir)/$($(package)_qttools_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_qtcharts_sha256_hash)  $($(package)_source_dir)/$($(package)_qtcharts_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_qtgraphicaleffects_sha256_hash)  $($(package)_source_dir)/$($(package)_qtgraphicaleffects_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_qtquickcontrols2_sha256_hash)  $($(package)_source_dir)/$($(package)_qtquickcontrols2_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_qtdeclarative_sha256_hash)  $($(package)_source_dir)/$($(package)_qtdeclarative_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   mkdir qtbase && \
   tar --no-same-owner --strip-components=1 -xf $($(package)_source) -C qtbase && \
@@ -206,6 +222,10 @@ define $(package)_extract_cmds
   tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qttools_file_name) -C qttools && \
   mkdir qtdeclarative && \
   tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtdeclarative_file_name) -C qtdeclarative && \
+  mkdir qtcharts && \
+  tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtcharts_file_name) -C qtcharts && \
+  mkdir qtgraphicaleffects && \
+  tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtgraphicaleffects_file_name) -C qtgraphicaleffects && \
   mkdir qtquickcontrols2 && \
   tar --no-same-owner --strip-components=1 -xf $($(package)_source_dir)/$($(package)_qtquickcontrols2_file_name) -C qtquickcontrols2
 endef
@@ -251,6 +271,9 @@ define $(package)_preprocess_cmds
   sed -i.old "s|updateqm.commands = \$$$$\$$$$LRELEASE|updateqm.commands = $($(package)_extract_dir)/qttools/bin/lrelease|" qttranslations/translations/translations.pro && \
   mkdir -p qtbase/mkspecs/macx-clang-linux &&\
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
+  cp -f $($(package)_patch_dir)/qt.pro . && \
+  cp -f $($(package)_patch_dir)/.gitmodules . && \
+  cp -f $($(package)_patch_dir)/.configure configure && \
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \
   cp -r qtbase/mkspecs/linux-arm-gnueabi-g++ qtbase/mkspecs/bitcoin-linux-g++ && \
   sed -i.old "s/arm-linux-gnueabi-/$(host)-/g" qtbase/mkspecs/bitcoin-linux-g++/qmake.conf && \
@@ -269,35 +292,23 @@ define $(package)_config_cmds
   export PKG_CONFIG_SYSROOT_DIR=/ && \
   export PKG_CONFIG_LIBDIR=$(host_prefix)/lib/pkgconfig && \
   export PKG_CONFIG_PATH=$(host_prefix)/share/pkgconfig  && \
+  cd .. && \
   ./configure $($(package)_config_opts) && \
-  echo "host_build: QT_CONFIG ~= s/system-zlib/zlib" >> mkspecs/qconfig.pri && \
-  echo "CONFIG += force_bootstrap" >> mkspecs/qconfig.pri && \
-  $(MAKE) sub-src-clean && \
-  cd ../qttranslations && ../qtbase/bin/qmake qttranslations.pro -o Makefile && \
-  cd translations && ../../qtbase/bin/qmake translations.pro -o Makefile && cd ../.. && \
-  cd qttools/src/linguist/lrelease/ && ../../../../qtbase/bin/qmake lrelease.pro -o Makefile && \
-  cd ../lupdate/ && ../../../../qtbase/bin/qmake lupdate.pro -o Makefile && cd ../../../.. && \
-  cd qtdeclarative && ../qtbase/bin/qmake qtdeclarative.pro -o Makefile && cd .. && \
-  cd qtquickcontrols2 && ../qtbase/bin/qmake qtquickcontrols2.pro -o Makefile && cd ..
+  echo "host_build: QT_CONFIG ~= s/system-zlib/zlib" >> qtbase/mkspecs/qconfig.pri && \
+  echo "CONFIG += force_bootstrap" >> qtbase/mkspecs/qconfig.pri  && \
+  echo "****************CONFIGURING****************"
 endef
 
 define $(package)_build_cmds
-  $(MAKE) -C src $(addprefix sub-,$($(package)_qt_libs)) && \
-  $(MAKE) -C ../qttools/src/linguist/lrelease && \
-  $(MAKE) -C ../qttools/src/linguist/lupdate && \
-  $(MAKE) -C ../qttranslations
-  $(MAKE) -C ../qttranslations && \
-  $(MAKE) -C ../qtdeclarative && \
-  $(MAKE) -C ../qtquickcontrols2
+  echo "****************BUILDING****************" && \
+  cd .. && \
+  $(MAKE) -C .
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) -C src INSTALL_ROOT=$($(package)_staging_dir) $(addsuffix -install_subtargets,$(addprefix sub-,$($(package)_qt_libs))) && cd .. && \
-  $(MAKE) -C qttools/src/linguist/lrelease INSTALL_ROOT=$($(package)_staging_dir) install_target && \
-  $(MAKE) -C qttools/src/linguist/lupdate INSTALL_ROOT=$($(package)_staging_dir) install_target && \
-  $(MAKE) -C qttranslations INSTALL_ROOT=$($(package)_staging_dir) install_subtargets && \
-  $(MAKE) -C qtdeclarative INSTALL_ROOT=$($(package)_staging_dir) install_subtargets && \
-  $(MAKE) -C qtquickcontrols2 INSTALL_ROOT=$($(package)_staging_dir) install_subtargets && \
+  echo "****************STAGING****************" && \
+  cd .. && \
+  $(MAKE) -C . INSTALL_ROOT=$($(package)_staging_dir) install_subtargets && \
   if `test -f qtbase/src/plugins/platforms/xcb/xcb-static/libxcb-static.a`; then \
     cp qtbase/src/plugins/platforms/xcb/xcb-static/libxcb-static.a $($(package)_staging_prefix_dir)/lib; \
   fi

--- a/depends/patches/qt/.configure
+++ b/depends/patches/qt/.configure
@@ -1,0 +1,17 @@
+#! /bin/sh
+
+srcpath=`dirname $0`
+srcpath=`(cd "$srcpath"; pwd)`
+configure=$srcpath/qtbase/configure
+if [ ! -e "$configure" ]; then
+    echo "$configure not found. Did you forget to run \"init-repository\"?" >&2
+    exit 1
+fi
+
+mkdir -p qtbase || exit
+
+echo "+ cd qtbase"
+cd qtbase || exit
+
+echo "+ $configure -top-level $@"
+exec "$configure" -top-level "$@"

--- a/depends/patches/qt/.gitmodules
+++ b/depends/patches/qt/.gitmodules
@@ -1,0 +1,50 @@
+[submodule "qtbase"]
+	path = qtbase
+	url = ../qtbase.git
+	branch = 5.13.2
+	status = essential
+[submodule "qtdeclarative"]
+	depends = qtbase
+	path = qtdeclarative
+	url = ../qtdeclarative.git
+	branch = 5.13.2
+	status = essential
+[submodule "qttools"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qttools
+	url = ../qttools.git
+	branch = 5.13.2
+	status = essential
+[submodule "qttranslations"]
+	depends = qttools
+	path = qttranslations
+	url = ../qttranslations.git
+	branch = 5.13.2
+	status = essential
+	priority = 30
+[submodule "qtgraphicaleffects"]
+	depends = qtdeclarative
+	path = qtgraphicaleffects
+	url = ../qtgraphicaleffects.git
+	branch = 5.13.2
+	status = addon
+[submodule "qtandroidextras"]
+	depends = qtbase
+	path = qtandroidextras
+	url = ../qtandroidextras.git
+	branch = 5.13.2
+	status = addon
+[submodule "qtquickcontrols2"]
+	depends = qtgraphicaleffects
+	path = qtquickcontrols2
+	url = ../qtquickcontrols2.git
+	branch = 5.13.2
+	status = essential
+[submodule "qtcharts"]
+	depends = qtbase
+	recommends = qtdeclarative
+	path = qtcharts
+	url = ../qtcharts.git
+	branch = 5.13.2
+	status = addon

--- a/depends/patches/qt/fix_android_base_head_conf.patch
+++ b/depends/patches/qt/fix_android_base_head_conf.patch
@@ -1,0 +1,10 @@
+--- new/qtbase/mkspecs/common/android-base-head.conf
++++ new/qtbase/mkspecs/common/android-base-head.conf
+@@ -67,6 +67,6 @@
+ QMAKE_PCH_OUTPUT_EXT    = .gch
+ 
+ QMAKE_CFLAGS_PRECOMPILE       = -x c-header -c ${QMAKE_PCH_INPUT} -o ${QMAKE_PCH_OUTPUT}
+-QMAKE_CFLAGS_USE_PRECOMPILE   = -include ${QMAKE_PCH_OUTPUT_BASE}
++QMAKE_CFLAGS_USE_PRECOMPILE   = -include-pch ${QMAKE_PCH_OUTPUT}
+ QMAKE_CXXFLAGS_PRECOMPILE     = -x c++-header -c ${QMAKE_PCH_INPUT} -o ${QMAKE_PCH_OUTPUT}
+ QMAKE_CXXFLAGS_USE_PRECOMPILE = $$QMAKE_CFLAGS_USE_PRECOMPILE

--- a/depends/patches/qt/qt.pro
+++ b/depends/patches/qt/qt.pro
@@ -1,0 +1,103 @@
+# Create the super cache so modules will add themselves to it.
+cache(, super)
+
+# Suppress the license check on subsequent "visits". The first
+# visit will skip it anyway due to not having a compiler set up
+# yet. This cannot be added to the super cache, because that is
+# read before spec_pre.prf, which flushes CONFIG. This does not
+# affect submodules, as they come with a .qmake.conf. But that
+# one sets the flag via qt_build_config.prf anyway.
+!QTDIR_build: cache(CONFIG, add, $$list(QTDIR_build))
+
+TEMPLATE      = subdirs
+
+CONFIG += prepare_docs qt_docs_targets
+
+# Extract submodules from .gitmodules.
+lines = $$cat(.gitmodules, lines)
+for (line, lines) {
+    mod = $$replace(line, "^\\[submodule \"([^\"]+)\"\\]$", \\1)
+    !equals(mod, $$line) {
+        module = $$mod
+        modules += $$mod
+    } else {
+        prop = $$replace(line, "^$$escape_expand(\\t)([^ =]+) *=.*$", \\1)
+        !equals(prop, $$line) {
+            val = $$replace(line, "^[^=]+= *", )
+            module.$${module}.$$prop = $$split(val)
+        } else {
+            error("Malformed line in .gitmodules: $$line")
+        }
+    }
+}
+QMAKE_INTERNAL_INCLUDED_FILES += $$PWD/.gitmodules
+
+QT_SKIP_MODULES =
+
+# This is a bit hacky, but a proper implementation is not worth it.
+args = $$QMAKE_EXTRA_ARGS
+contains(args, -redo): \
+    args += $$cat($$OUT_PWD/config.opt, lines)
+for (ever) {
+    isEmpty(args): break()
+    a = $$take_first(args)
+
+    equals(a, -skip) {
+        isEmpty(args): break()
+        m = $$take_first(args)
+        contains(m, -.*): next()
+        m ~= s/^(qt)?/qt/
+        !contains(modules, $$m): \
+            error("-skip command line argument used with non-existent module '$$m'.")
+        QT_SKIP_MODULES += $$m
+    }
+}
+
+modules = $$sort_depends(modules, module., .depends .recommends .serialize)
+modules = $$reverse(modules)
+for (mod, modules) {
+    project = $$eval(module.$${mod}.project)
+    equals(project, -): \
+        next()
+
+    deps = $$eval(module.$${mod}.depends)
+    recs = $$eval(module.$${mod}.recommends) $$eval(module.$${mod}.serialize)
+    for (d, $$list($$deps $$recs)): \
+        !contains(modules, $$d): \
+            error("'$$mod' depends on undeclared '$$d'.")
+
+    contains(QT_SKIP_MODULES, $$mod): \
+        next()
+    !isEmpty(QT_BUILD_MODULES):!contains(QT_BUILD_MODULES, $$mod): \
+        next()
+
+    isEmpty(project) {
+        !exists($$mod/$${mod}.pro): \
+            next()
+        $${mod}.subdir = $$mod
+    } else {
+        !exists($$mod/$$project): \
+            next()
+        $${mod}.file = $$mod/$$project
+        $${mod}.makefile = Makefile
+    }
+    $${mod}.target = module-$$mod
+
+    for (d, deps) {
+        !contains(SUBDIRS, $$d) {
+            $${mod}.target =
+            break()
+        }
+        $${mod}.depends += $$d
+    }
+    isEmpty($${mod}.target): \
+        next()
+    for (d, recs) {
+        contains(SUBDIRS, $$d): \
+            $${mod}.depends += $$d
+    }
+
+    SUBDIRS += $$mod
+}
+
+load(qt_configure)


### PR DESCRIPTION
This PR attempts to add additional Qt modules, namely QtDeclarative and QtQuickControls2 to the depends build, thereby allowing use of QML/QtQuick in the QT GUI in place of QtWidgets. 

Compilation of QtDeclarative seems to complete just fine, however QtQuickControls2 fails with :- 

`Some of the required modules (qtHaveModule(quick)) are not available.`

QtQuick is a part of QtDeclarative, and when i look at the finished product, it is most definitely there, but for some reason, QtQuickControls2 does not find it.
